### PR TITLE
Fix some minor compilation issues

### DIFF
--- a/components/esp_webrtc/impl/peer_default/CMakeLists.txt
+++ b/components/esp_webrtc/impl/peer_default/CMakeLists.txt
@@ -2,6 +2,6 @@ idf_component_register(INCLUDE_DIRS ./include)
 
 get_filename_component(BASE_DIR ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 add_prebuilt_library(${BASE_DIR} "${CMAKE_CURRENT_SOURCE_DIR}/libs/${IDF_TARGET}/libpeer_default.a"
-                     PRIV_REQUIRES ${BASE_DIR} esp_timer)
+                     PRIV_REQUIRES ${BASE_DIR} esp_timer espressif__esp_libsrtp)
 target_link_libraries(${COMPONENT_LIB}  INTERFACE "-L ${CMAKE_CURRENT_SOURCE_DIR}/libs/${IDF_TARGET}")
 target_link_libraries(${COMPONENT_LIB}  INTERFACE peer_default)

--- a/components/media_lib_sal/port/media_lib_os_freertos.c
+++ b/components/media_lib_sal/port/media_lib_os_freertos.c
@@ -40,7 +40,11 @@
 #include "esp_idf_version.h"
 
 #if CONFIG_FREERTOS_ENABLE_TASK_SNAPSHOT
+#if (ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 2, 0))
+#include "esp_private/freertos_debug.h"
+#else
 #include "freertos/task_snapshot.h"
+#endif
 #endif
 
 #ifdef __XTENSA__


### PR DESCRIPTION
Hi, sharing some minor fixes which pop-up when added ESP32 WebRTC solution to this [MQTT brokerless example](https://github.com/espressif/esp-protocols/pull/840)

* `freertos/task_snapshot.h` is deprecated in IDF >= v5.2
* `peer_default` lib uses SRTP API directly, need to define a link dependency
* `http_client` added one more event -- already applied in ab689ad

https://github.com/espressif/esp-webrtc-solution/blob/ccff3bd65cea750bf6c0abcf9d95b931ba9329f0/components/esp_webrtc/impl/apprtc_signal/https_client.c#L51-L52