### PR TITLE
feat: add public apis to set video/audio bitrate

### DIFF
--- a/components/esp_webrtc/include/esp_webrtc.h
+++ b/components/esp_webrtc/include/esp_webrtc.h
@@ -298,6 +298,40 @@ int esp_webrtc_stop(esp_webrtc_handle_t rtc_handle);
  */
 int esp_webrtc_close(esp_webrtc_handle_t rtc_handle);
 
+/**
+ * @brief  Set video bitrate for encoder
+ *
+ * @note   This can be called before or after WebRTC starts. If called before start,
+ *         the bitrate will be applied when the capture sink is created.
+ *         If called during streaming, the bitrate is updated immediately without restart.
+ *
+ * @param[in]  rtc_handle  WebRTC handle
+ * @param[in]  bps         Target bitrate in bits per second (e.g., 700000 for 700 kbps)
+ *
+ * @return
+ *      - 0                         On success
+ *      - ESP_PEER_ERR_INVALID_ARG  Invalid argument
+ *      - Others                    Error from capture sink
+ */
+int esp_webrtc_set_video_bitrate(esp_webrtc_handle_t rtc_handle, uint32_t bps);
+
+/**
+ * @brief  Set audio bitrate for encoder
+ *
+ * @note   This can be called before or after WebRTC starts. If called before start,
+ *         the bitrate will be applied when the capture sink is created.
+ *         If called during streaming, the bitrate is updated immediately without restart.
+ *
+ * @param[in]  rtc_handle  WebRTC handle
+ * @param[in]  bps         Target bitrate in bits per second (e.g., 64000 for 64 kbps)
+ *
+ * @return
+ *      - 0                         On success
+ *      - ESP_PEER_ERR_INVALID_ARG  Invalid argument
+ *      - Others                    Error from capture sink
+ */
+int esp_webrtc_set_audio_bitrate(esp_webrtc_handle_t rtc_handle, uint32_t bps);
+
 #ifdef __cplusplus
 }
 #endif

--- a/components/esp_webrtc/src/esp_webrtc.c
+++ b/components/esp_webrtc/src/esp_webrtc.c
@@ -97,6 +97,12 @@ typedef struct {
     uint8_t  vid_send_num;
     uint8_t  aud_recv_num;
     uint8_t  vid_recv_num;
+
+    // Pending bitrate settings (applied when sink is created)
+    uint32_t pending_video_bitrate_bps;
+    bool     video_bitrate_pending;
+    uint32_t pending_audio_bitrate_bps;
+    bool     audio_bitrate_pending;
 } webrtc_t;
 
 static const char *TAG = "webrtc";
@@ -598,6 +604,30 @@ static int pc_start(webrtc_t *rtc, esp_peer_ice_server_cfg_t *server_info, int s
     }
     esp_capture_sink_setup(rtc->media_provider.capture, 0, &sink_cfg, &rtc->capture_path);
     esp_capture_sink_enable(rtc->capture_path, ESP_CAPTURE_RUN_MODE_ALWAYS);
+
+    // Apply pending bitrate settings now that sink exists
+    if (rtc->video_bitrate_pending && rtc->capture_path) {
+        int bitrate_ret = esp_capture_sink_set_bitrate(rtc->capture_path, ESP_CAPTURE_STREAM_TYPE_VIDEO, 
+                                                        rtc->pending_video_bitrate_bps);
+        if (bitrate_ret == ESP_CAPTURE_ERR_OK) {
+            ESP_LOGI(TAG, "Applied pending video bitrate: %lu bps", (unsigned long)rtc->pending_video_bitrate_bps);
+        } else {
+            ESP_LOGW(TAG, "Failed to apply pending video bitrate: %d", bitrate_ret);
+        }
+        rtc->video_bitrate_pending = false;
+    }
+    
+    if (rtc->audio_bitrate_pending && rtc->capture_path) {
+        int bitrate_ret = esp_capture_sink_set_bitrate(rtc->capture_path, ESP_CAPTURE_STREAM_TYPE_AUDIO, 
+                                                        rtc->pending_audio_bitrate_bps);
+        if (bitrate_ret == ESP_CAPTURE_ERR_OK) {
+            ESP_LOGI(TAG, "Applied pending audio bitrate: %lu bps", (unsigned long)rtc->pending_audio_bitrate_bps);
+        } else {
+            ESP_LOGW(TAG, "Failed to apply pending audio bitrate: %d", bitrate_ret);
+        }
+        rtc->audio_bitrate_pending = false;
+    }
+
     return ret;
 }
 
@@ -947,4 +977,58 @@ int esp_webrtc_close(esp_webrtc_handle_t handle)
     SAFE_FREE(rtc->aud_fifo);
     free(rtc);
     return ESP_PEER_ERR_NONE;
+}
+
+int esp_webrtc_set_video_bitrate(esp_webrtc_handle_t handle, uint32_t bps)
+{
+    if (handle == NULL) {
+        return ESP_PEER_ERR_INVALID_ARG;
+    }
+    
+    webrtc_t *rtc = (webrtc_t *)handle;
+    
+    // If capture path exists, apply immediately
+    if (rtc->capture_path) {
+        int ret = esp_capture_sink_set_bitrate(rtc->capture_path, ESP_CAPTURE_STREAM_TYPE_VIDEO, bps);
+        if (ret == ESP_CAPTURE_ERR_OK) {
+            ESP_LOGI(TAG, "Set video bitrate: %lu bps", (unsigned long)bps);
+            return 0;
+        } else {
+            ESP_LOGW(TAG, "Failed to set video bitrate: %d", ret);
+            return ret;
+        }
+    }
+    
+    // Otherwise, store as pending
+    rtc->pending_video_bitrate_bps = bps;
+    rtc->video_bitrate_pending = true;
+    ESP_LOGI(TAG, "Video bitrate %lu bps will be applied when WebRTC starts", (unsigned long)bps);
+    return 0;
+}
+
+int esp_webrtc_set_audio_bitrate(esp_webrtc_handle_t handle, uint32_t bps)
+{
+    if (handle == NULL) {
+        return ESP_PEER_ERR_INVALID_ARG;
+    }
+    
+    webrtc_t *rtc = (webrtc_t *)handle;
+    
+    // If capture path exists, apply immediately
+    if (rtc->capture_path) {
+        int ret = esp_capture_sink_set_bitrate(rtc->capture_path, ESP_CAPTURE_STREAM_TYPE_AUDIO, bps);
+        if (ret == ESP_CAPTURE_ERR_OK) {
+            ESP_LOGI(TAG, "Set audio bitrate: %lu bps", (unsigned long)bps);
+            return 0;
+        } else {
+            ESP_LOGW(TAG, "Failed to set audio bitrate: %d", ret);
+            return ret;
+        }
+    }
+    
+    // Otherwise, store as pending
+    rtc->pending_audio_bitrate_bps = bps;
+    rtc->audio_bitrate_pending = true;
+    ESP_LOGI(TAG, "Audio bitrate %lu bps will be applied when WebRTC starts", (unsigned long)bps);
+    return 0;
 }


### PR DESCRIPTION
## Description

This PR closes #108: adds public runtime bitrate setters to esp_webrtc.

```
int esp_webrtc_set_video_bitrate(esp_webrtc_handle_t, uint32_t bps);

int esp_webrtc_set_audio_bitrate(esp_webrtc_handle_t, uint32_t bps);
```

### Behavior

If `rtc->capture_path` exists, call `esp_capture_sink_set_bitrate()` immediately (both for Video and Audio).

If called before start, cache the values and apply them in `pc_start()` right after `esp_capture_sink_setup()` / `esp_capture_sink_enable()`.

### Why here
`esp-webrtc-solution` integrates `esp_capture` as its media layer; providing first-class bitrate control at this level makes it straightforward for applications to adapt quality without restarting streams. 

Public API docs (headers) explain that bps is bits per second and that calls are valid before or during streaming.

## Related

- Companion fix in `esp-gmf/esp_capture` (https://github.com/espressif/esp-gmf/issues/29) to ensure `esp_capture_sink_set_bitrate()` forwards to the path manager and encoder (so runtime changes actually apply).

## Testing

### Environments

ESP-IDF: latest
Board: ESP32-P4

### Scenarios

- During stream: Run any sender demo (e.g., Video Call). Invoke `esp_webrtc_set_video_bitrate(rtc, 300000)`. Expect lower throughput/quality.

- Pre-start (pending): Call `esp_webrtc_set_video_bitrate(rtc, 500000)` before` esp_webrtc_start().` Start streaming and confirm bitrate is applied after `pc_start()` creates/enables the sink.

- Audio path: Invoke `esp_webrtc_set_audio_bitrate(rtc, 64000)` and track payload sizes or encoder stats.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [X] 🚨 This PR does not introduce breaking changes.
- [X] All CI checks (GH Actions) pass.
- [X] Documentation is updated as needed.
- [X] Tests are updated or added as necessary.
- [X] Code is well-commented, especially in complex areas.
- [X] Git history is clean — commits are squashed to the minimum necessary.
