### PR TITLE
openai_demo: document ESP-VoCat profiles and restore build compatibility

### DIFF
--- a/solutions/openai_demo/CMakeLists.txt
+++ b/solutions/openai_demo/CMakeLists.txt
@@ -14,3 +14,8 @@ endif()
 add_compile_definitions(OPENAI_API_KEY="$ENV{OPENAI_API_KEY}")
 
 project(openai_demo)
+
+# esp_asrc 1.0.1 uses a signed format specifier for allocation sizes. Keep the
+# workaround scoped to that managed component until the registry release fixes it.
+idf_component_get_property(esp_asrc_lib espressif__esp_asrc COMPONENT_LIB)
+target_compile_options(${esp_asrc_lib} PRIVATE -Wno-error=format)

--- a/solutions/openai_demo/README.md
+++ b/solutions/openai_demo/README.md
@@ -56,6 +56,15 @@ idf.py gen-bmgr-config -b YOUR_BOARD_NAME
 idf.py gen-bmgr-config -b esp32_p4_function_ev_board
 ```
 
+For ESP-VoCat (EchoEar), select the profile matching the PCB revision printed
+on the board. The `esp_vocat_1_2` profile has been verified on ESP-VoCat v1.2:
+
+```bash
+idf.py gen-bmgr-config -b esp_vocat_1_0
+# or
+idf.py gen-bmgr-config -b esp_vocat_1_2
+```
+
 Build and flash:
 
 ```bash


### PR DESCRIPTION
## Summary

- document the ESP-VoCat (EchoEar) v1.0 and v1.2 board-manager profiles for the OpenAI demo
- note that the v1.2 profile was verified on ESP-VoCat v1.2 hardware
- scope the esp_asrc 1.0.1 format-warning workaround to the managed esp_asrc component

## Testing

- ESP-IDF v5.4.4
- generated the board configuration with `idf.py gen-bmgr-config -b esp_vocat_1_2`
- built `solutions/openai_demo` successfully
- resulting application fits the existing 3 MiB application partition

This contribution contains only generic ESP-VoCat documentation and build compatibility changes; it does not include product-specific application code.